### PR TITLE
Add badge and color support for table columns

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -1,3 +1,14 @@
+@php
+    $badgeColors = [
+        'danger'  => ['bg' => '#fef2f2', 'text' => '#dc2626', 'darkBg' => '#450a0a', 'darkText' => '#fca5a5'],
+        'success' => ['bg' => '#f0fdf4', 'text' => '#16a34a', 'darkBg' => '#052e16', 'darkText' => '#86efac'],
+        'warning' => ['bg' => '#fefce8', 'text' => '#ca8a04', 'darkBg' => '#422006', 'darkText' => '#fde047'],
+        'info'    => ['bg' => '#eff6ff', 'text' => '#2563eb', 'darkBg' => '#172554', 'darkText' => '#93c5fd'],
+        'primary' => ['bg' => '#eef2ff', 'text' => '#6366f1', 'darkBg' => '#1e1b4b', 'darkText' => '#a5b4fc'],
+        'gray'    => ['bg' => '#f9fafb', 'text' => '#4b5563', 'darkBg' => '#1f2937', 'darkText' => '#d1d5db'],
+    ];
+@endphp
+
 <div class="fi-ta" style="background-color: white; border-radius: 0.75rem; border: 1px solid #e5e7eb; overflow: hidden;">
     @if($heading)
         <div class="fi-ta-header" style="padding: 1rem 1.5rem; border-bottom: 1px solid #e5e7eb;">
@@ -21,7 +32,29 @@
                     <tr class="fi-ta-row" style="border-bottom: 1px solid #e5e7eb; {{ $striped && $index % 2 === 1 ? 'background-color: #f9fafb;' : '' }}">
                         @foreach($columns as $column)
                             <td class="fi-ta-cell" style="padding: 0.75rem 1rem; font-size: 0.875rem; color: #374151; white-space: nowrap;">
-                                {{ $record[$column['name']] ?? '' }}
+                                @php
+                                    $value = $record[$column['name']] ?? '';
+                                    $isBadge = $column['badge'] ?? false;
+                                    $colorName = $column['color'] ?? null;
+
+                                    if ($isBadge && $colorName === null && isset($column['getColor']) && $column['getColor'] !== null) {
+                                        $colorName = ($column['getColor'])($value);
+                                    }
+
+                                    $colors = $isBadge && $colorName && isset($badgeColors[$colorName]) ? $badgeColors[$colorName] : null;
+                                @endphp
+
+                                @if($isBadge)
+                                    @php
+                                        $bg = $colors ? ($darkMode ? $colors['darkBg'] : $colors['bg']) : ($darkMode ? '#1f2937' : '#f3f4f6');
+                                        $text = $colors ? ($darkMode ? $colors['darkText'] : $colors['text']) : ($darkMode ? '#d1d5db' : '#374151');
+                                    @endphp
+                                    <span style="display: inline-flex; align-items: center; border-radius: 9999px; padding: 0.25rem 0.75rem; font-size: 0.75rem; font-weight: 600; background-color: {{ $bg }}; color: {{ $text }};">
+                                        {{ $value }}
+                                    </span>
+                                @else
+                                    {{ $value }}
+                                @endif
                             </td>
                         @endforeach
                     </tr>

--- a/src/Renderers/TableRenderer.php
+++ b/src/Renderers/TableRenderer.php
@@ -42,17 +42,38 @@ class TableRenderer extends BaseRenderer
 
     protected function renderContent(): string
     {
-        $columnData = array_map(fn ($column) => [
-            'name' => $this->safeCall(fn () => $column->getName(), ''),
-            'label' => $this->safeCall(fn () => $column->getLabel(), ''),
-        ], $this->columns);
+        $columnData = array_map(
+            fn ($column) => $this->extractColumnData($column),
+            $this->columns,
+        );
 
         return view('filament-shot::components.table', [
             'columns' => $columnData,
             'records' => $this->records,
             'heading' => $this->heading,
             'striped' => $this->striped,
+            'darkMode' => $this->isDarkMode(),
         ])->render();
+    }
+
+    protected function extractColumnData(mixed $column): array
+    {
+        if (is_array($column)) {
+            return [
+                'name' => $column['name'] ?? '',
+                'label' => $column['label'] ?? str($column['name'] ?? '')->headline()->toString(),
+                'badge' => $column['badge'] ?? false,
+                'color' => $column['color'] ?? null,
+            ];
+        }
+
+        return [
+            'name' => $this->safeCall(fn () => $column->getName(), ''),
+            'label' => $this->safeCall(fn () => $column->getLabel(), ''),
+            'badge' => $this->safeCall(fn () => $column->isBadge(), false),
+            'color' => null, // Color is resolved per-record in the template
+            'getColor' => method_exists($column, 'getColor') ? fn ($state) => $this->safeCall(fn () => $column->getColor($state), null) : null,
+        ];
     }
 
     protected function safeCall(callable $callback, mixed $default): mixed

--- a/tests/Feature/TableCaptureTest.php
+++ b/tests/Feature/TableCaptureTest.php
@@ -23,3 +23,25 @@ it('saves table screenshot as PNG', function () {
 
     @unlink($path);
 })->group('integration');
+
+it('saves table with badge columns as PNG', function () {
+    $path = sys_get_temp_dir() . '/filament-shot-table-badge-test.png';
+
+    FilamentShot::table()
+        ->columns([
+            TextColumn::make('name'),
+            TextColumn::make('status')->badge()->color('danger'),
+        ])
+        ->records([
+            ['name' => 'Alice', 'status' => 'Blocked'],
+            ['name' => 'Bob', 'status' => 'Active'],
+        ])
+        ->save($path);
+
+    expect(file_exists($path))->toBeTrue();
+
+    $header = file_get_contents($path, false, null, 0, 8);
+    expect(str_starts_with($header, "\x89PNG"))->toBeTrue();
+
+    @unlink($path);
+})->group('integration');

--- a/tests/Unit/TableRendererTest.php
+++ b/tests/Unit/TableRendererTest.php
@@ -71,3 +71,65 @@ it('renders table with heading', function () {
         ->toContain('Users List')
         ->toContain('fi-ta-header');
 });
+
+it('renders badge column from TextColumn', function () {
+    $html = FilamentShot::table()
+        ->columns([
+            TextColumn::make('status')->badge(),
+        ])
+        ->records([
+            ['status' => 'Active'],
+        ])
+        ->toHtml();
+
+    expect($html)
+        ->toContain('Active')
+        ->toContain('border-radius: 9999px');
+});
+
+it('renders badge column with color from TextColumn', function () {
+    $html = FilamentShot::table()
+        ->columns([
+            TextColumn::make('status')->badge()->color('danger'),
+        ])
+        ->records([
+            ['status' => 'Blocked'],
+        ])
+        ->toHtml();
+
+    expect($html)
+        ->toContain('Blocked')
+        ->toContain('border-radius: 9999px')
+        ->toContain('#dc2626');
+});
+
+it('renders badge column from array definition', function () {
+    $html = FilamentShot::table()
+        ->columns([
+            ['name' => 'status', 'badge' => true, 'color' => 'success'],
+        ])
+        ->records([
+            ['status' => 'Active'],
+        ])
+        ->toHtml();
+
+    expect($html)
+        ->toContain('Active')
+        ->toContain('border-radius: 9999px')
+        ->toContain('#16a34a');
+});
+
+it('renders non-badge columns as plain text', function () {
+    $html = FilamentShot::table()
+        ->columns([
+            TextColumn::make('name'),
+        ])
+        ->records([
+            ['name' => 'Alice'],
+        ])
+        ->toHtml();
+
+    expect($html)
+        ->toContain('Alice')
+        ->not->toContain('border-radius: 9999px');
+});


### PR DESCRIPTION
## Summary
- Add badge-styled column rendering with colored pills matching Filament's `TextColumn::make('status')->badge()->color('danger')` API
- Support both `TextColumn` objects and plain array column definitions (`['name' => 'status', 'badge' => true, 'color' => 'success']`)
- Hardcoded color map for all 6 Filament colors (danger, success, warning, info, primary, gray) with light/dark mode variants

## Test plan
- [x] Badge column from `TextColumn::make('status')->badge()`
- [x] Badge with color from `TextColumn::make('status')->badge()->color('danger')`
- [x] Badge from array definition
- [x] Non-badge columns still render as plain text
- [x] Integration test: capture table with badge columns as valid PNG
- [x] All 46 tests pass, pint clean, phpstan clean

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)