### PR TITLE
Use Filament CSS classes and OKLCH colors for table/badge rendering

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -1,27 +1,16 @@
-@php
-    $badgeColors = [
-        'danger'  => ['bg' => '#fef2f2', 'text' => '#dc2626', 'darkBg' => '#450a0a', 'darkText' => '#fca5a5'],
-        'success' => ['bg' => '#f0fdf4', 'text' => '#16a34a', 'darkBg' => '#052e16', 'darkText' => '#86efac'],
-        'warning' => ['bg' => '#fefce8', 'text' => '#ca8a04', 'darkBg' => '#422006', 'darkText' => '#fde047'],
-        'info'    => ['bg' => '#eff6ff', 'text' => '#2563eb', 'darkBg' => '#172554', 'darkText' => '#93c5fd'],
-        'primary' => ['bg' => '#eef2ff', 'text' => '#6366f1', 'darkBg' => '#1e1b4b', 'darkText' => '#a5b4fc'],
-        'gray'    => ['bg' => '#f9fafb', 'text' => '#4b5563', 'darkBg' => '#1f2937', 'darkText' => '#d1d5db'],
-    ];
-@endphp
-
-<div class="fi-ta" style="background-color: white; border-radius: 0.75rem; border: 1px solid #e5e7eb; overflow: hidden;">
+<div class="fi-ta-ctn" style="flex-direction: column; overflow: hidden;">
     @if($heading)
-        <div class="fi-ta-header" style="padding: 1rem 1.5rem; border-bottom: 1px solid #e5e7eb;">
-            <h3 style="font-size: 1rem; font-weight: 600; color: #111827; margin: 0;">{{ $heading }}</h3>
+        <div class="fi-ta-header">
+            <p class="fi-ta-header-heading">{{ $heading }}</p>
         </div>
     @endif
 
-    <div style="overflow-x: auto;">
-        <table style="width: 100%; border-collapse: collapse; text-align: left;">
+    <div class="fi-ta-content-ctn">
+        <table class="fi-ta-table">
             <thead>
-                <tr style="border-bottom: 1px solid #e5e7eb;">
+                <tr>
                     @foreach($columns as $column)
-                        <th class="fi-ta-header-cell" style="padding: 0.75rem 1rem; font-size: 0.75rem; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em;">
+                        <th class="fi-ta-header-cell">
                             {{ $column['label'] }}
                         </th>
                     @endforeach
@@ -29,39 +18,45 @@
             </thead>
             <tbody>
                 @forelse($records as $index => $record)
-                    <tr class="fi-ta-row" style="border-bottom: 1px solid #e5e7eb; {{ $striped && $index % 2 === 1 ? 'background-color: #f9fafb;' : '' }}">
+                    <tr class="fi-ta-row {{ $striped && $index % 2 === 1 ? 'fi-striped' : '' }}">
                         @foreach($columns as $column)
-                            <td class="fi-ta-cell" style="padding: 0.75rem 1rem; font-size: 0.875rem; color: #374151; white-space: nowrap;">
+                            <td class="fi-ta-cell">
                                 @php
                                     $value = $record[$column['name']] ?? '';
                                     $isBadge = $column['badge'] ?? false;
-                                    $colorName = $column['color'] ?? null;
-
-                                    if ($isBadge && $colorName === null && isset($column['getColor']) && $column['getColor'] !== null) {
-                                        $colorName = ($column['getColor'])($value);
-                                    }
-
-                                    $colors = $isBadge && $colorName && isset($badgeColors[$colorName]) ? $badgeColors[$colorName] : null;
                                 @endphp
 
                                 @if($isBadge)
                                     @php
-                                        $bg = $colors ? ($darkMode ? $colors['darkBg'] : $colors['bg']) : ($darkMode ? '#1f2937' : '#f3f4f6');
-                                        $text = $colors ? ($darkMode ? $colors['darkText'] : $colors['text']) : ($darkMode ? '#d1d5db' : '#374151');
+                                        $colorName = $column['color'] ?? null;
+
+                                        if ($colorName === null && isset($column['getColor'])) {
+                                            $colorName = ($column['getColor'])($value);
+                                        }
+
+                                        $badgeClasses = \CCK\FilamentShot\Renderers\TableRenderer::resolveBadgeClasses($colorName);
                                     @endphp
-                                    <span style="display: inline-flex; align-items: center; border-radius: 9999px; padding: 0.25rem 0.75rem; font-size: 0.75rem; font-weight: 600; background-color: {{ $bg }}; color: {{ $text }};">
-                                        {{ $value }}
-                                    </span>
+                                    <div class="fi-ta-text fi-ta-text-has-badges fi-ta-text-item">
+                                        <span class="fi-badge fi-size-sm {{ $badgeClasses }}">
+                                            {{ $value }}
+                                        </span>
+                                    </div>
                                 @else
-                                    {{ $value }}
+                                    <div class="fi-ta-text">
+                                        <span class="fi-ta-text-item fi-size-sm">{{ $value }}</span>
+                                    </div>
                                 @endif
                             </td>
                         @endforeach
                     </tr>
                 @empty
                     <tr>
-                        <td colspan="{{ count($columns) }}" style="padding: 2rem; text-align: center; font-size: 0.875rem; color: #9ca3af;">
-                            No records found.
+                        <td colspan="{{ count($columns) }}">
+                            <div class="fi-ta-empty-state">
+                                <div class="fi-ta-empty-state-content">
+                                    <p class="fi-ta-empty-state-description">No records found.</p>
+                                </div>
+                            </div>
                         </td>
                     </tr>
                 @endforelse

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -9,6 +9,7 @@
 
         :root {
             --primary-color: {{ $primaryColor }};
+            {!! $colorVariables !!}
         }
 
         * {

--- a/src/Concerns/HasTheme.php
+++ b/src/Concerns/HasTheme.php
@@ -2,11 +2,19 @@
 
 namespace CCK\FilamentShot\Concerns;
 
+use Filament\Support\Colors\Color;
+use Filament\Support\Colors\ColorManager;
+
 trait HasTheme
 {
     protected ?bool $darkMode = null;
 
     protected ?string $primaryColor = null;
+
+    /**
+     * @var array<string, array<int, string>|string>
+     */
+    protected array $colors = [];
 
     public function darkMode(): static
     {
@@ -22,9 +30,20 @@ trait HasTheme
         return $this;
     }
 
+    /**
+     * @param  array<string, array<int, string>|string>  $colors
+     */
+    public function colors(array $colors): static
+    {
+        $this->colors = $colors;
+
+        return $this;
+    }
+
     public function primaryColor(string $color): static
     {
         $this->primaryColor = $color;
+        $this->colors['primary'] = $color;
 
         return $this;
     }
@@ -37,5 +56,43 @@ trait HasTheme
     public function getPrimaryColor(): string
     {
         return $this->primaryColor ?? config('filament-shot.theme.primary_color', '#6366f1');
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function getResolvedColors(): array
+    {
+        $defaults = ColorManager::DEFAULT_COLORS;
+        $configColors = config('filament-shot.theme.colors', []);
+        $merged = array_merge($defaults, $configColors, $this->colors);
+
+        $resolved = [];
+
+        foreach ($merged as $name => $color) {
+            if (is_string($color)) {
+                $resolved[$name] = Color::generatePalette($color);
+            } elseif (is_array($color)) {
+                $resolved[$name] = array_map(
+                    fn (string $value): string => str_contains($value, 'oklch') ? $value : Color::convertToOklch($value),
+                    $color,
+                );
+            }
+        }
+
+        return $resolved;
+    }
+
+    public function getColorCssVariables(): string
+    {
+        $css = '';
+
+        foreach ($this->getResolvedColors() as $name => $shades) {
+            foreach ($shades as $shade => $value) {
+                $css .= "--{$name}-{$shade}: {$value};\n";
+            }
+        }
+
+        return $css;
     }
 }

--- a/src/Renderers/BaseRenderer.php
+++ b/src/Renderers/BaseRenderer.php
@@ -22,6 +22,7 @@ abstract class BaseRenderer
         return view('filament-shot::layouts.base', [
             'darkMode' => $this->isDarkMode(),
             'primaryColor' => $this->getPrimaryColor(),
+            'colorVariables' => $this->getColorCssVariables(),
             'themeCss' => $resolver->getThemeCssContent(),
             'extraCss' => $resolver->getExtraCss(),
             'content' => $this->renderContent(),

--- a/src/Renderers/TableRenderer.php
+++ b/src/Renderers/TableRenderer.php
@@ -2,6 +2,9 @@
 
 namespace CCK\FilamentShot\Renderers;
 
+use Filament\Support\Facades\FilamentColor;
+use Filament\Support\View\Components\BadgeComponent;
+
 class TableRenderer extends BaseRenderer
 {
     protected array $columns = [];
@@ -52,7 +55,6 @@ class TableRenderer extends BaseRenderer
             'records' => $this->records,
             'heading' => $this->heading,
             'striped' => $this->striped,
-            'darkMode' => $this->isDarkMode(),
         ])->render();
     }
 
@@ -71,9 +73,27 @@ class TableRenderer extends BaseRenderer
             'name' => $this->safeCall(fn () => $column->getName(), ''),
             'label' => $this->safeCall(fn () => $column->getLabel(), ''),
             'badge' => $this->safeCall(fn () => $column->isBadge(), false),
-            'color' => null, // Color is resolved per-record in the template
-            'getColor' => method_exists($column, 'getColor') ? fn ($state) => $this->safeCall(fn () => $column->getColor($state), null) : null,
+            'color' => null,
+            'getColor' => method_exists($column, 'getColor')
+                ? fn ($state) => $this->safeCall(fn () => $column->getColor($state), null)
+                : null,
         ];
+    }
+
+    /**
+     * Resolve Filament CSS classes for a badge color.
+     *
+     * @return string CSS class string (e.g. "fi-color fi-color-danger fi-text-color-600 dark:fi-text-color-300")
+     */
+    public static function resolveBadgeClasses(?string $color): string
+    {
+        if ($color === null) {
+            $color = 'primary';
+        }
+
+        $classes = FilamentColor::getComponentClasses(BadgeComponent::class, $color);
+
+        return implode(' ', $classes);
     }
 
     protected function safeCall(callable $callback, mixed $default): mixed

--- a/tests/Unit/TableRendererTest.php
+++ b/tests/Unit/TableRendererTest.php
@@ -22,7 +22,7 @@ it('renders table with columns and records', function () {
         ->toContain('alice@example.com')
         ->toContain('Bob')
         ->toContain('bob@example.com')
-        ->toContain('fi-ta');
+        ->toContain('fi-ta-ctn');
 });
 
 it('renders column headers', function () {
@@ -57,7 +57,7 @@ it('supports striped rows', function () {
         ->striped()
         ->toHtml();
 
-    expect($html)->toContain('background-color: #f9fafb');
+    expect($html)->toContain('fi-striped');
 });
 
 it('renders table with heading', function () {
@@ -84,7 +84,7 @@ it('renders badge column from TextColumn', function () {
 
     expect($html)
         ->toContain('Active')
-        ->toContain('border-radius: 9999px');
+        ->toContain('fi-badge');
 });
 
 it('renders badge column with color from TextColumn', function () {
@@ -99,8 +99,8 @@ it('renders badge column with color from TextColumn', function () {
 
     expect($html)
         ->toContain('Blocked')
-        ->toContain('border-radius: 9999px')
-        ->toContain('#dc2626');
+        ->toContain('fi-badge')
+        ->toContain('fi-color-danger');
 });
 
 it('renders badge column from array definition', function () {
@@ -115,8 +115,8 @@ it('renders badge column from array definition', function () {
 
     expect($html)
         ->toContain('Active')
-        ->toContain('border-radius: 9999px')
-        ->toContain('#16a34a');
+        ->toContain('fi-badge')
+        ->toContain('fi-color-success');
 });
 
 it('renders non-badge columns as plain text', function () {
@@ -131,5 +131,35 @@ it('renders non-badge columns as plain text', function () {
 
     expect($html)
         ->toContain('Alice')
-        ->not->toContain('border-radius: 9999px');
+        ->toContain('fi-ta-text-item')
+        ->not->toContain('class="fi-badge');
+});
+
+it('renders badge with default primary color when no color specified', function () {
+    $html = FilamentShot::table()
+        ->columns([
+            TextColumn::make('status')->badge(),
+        ])
+        ->records([
+            ['status' => 'Pending'],
+        ])
+        ->toHtml();
+
+    expect($html)
+        ->toContain('fi-badge')
+        ->toContain('fi-color-primary');
+});
+
+it('injects OKLCH color CSS variables', function () {
+    $html = FilamentShot::table()
+        ->columns([TextColumn::make('name')])
+        ->records([])
+        ->renderHtml();
+
+    expect($html)
+        ->toContain('--danger-50:')
+        ->toContain('--success-50:')
+        ->toContain('--primary-50:')
+        ->toContain('--gray-50:')
+        ->toContain('oklch');
 });


### PR DESCRIPTION
## Summary
- Replace hardcoded inline styles with Filament's actual CSS classes (`fi-ta-ctn`, `fi-ta-header-cell`, `fi-ta-row`, `fi-ta-cell`, `fi-badge`, `fi-color-*`, etc.)
- Inject OKLCH CSS variables for all 6 Filament color roles × 11 shades into `:root` so the compiled `theme.css` works correctly
- Resolve badge CSS classes via Filament's own `ColorManager::getComponentClasses(BadgeComponent::class, $color)` — badges now render identically to Filament's real UI
- Add `colors()` method to `HasTheme` trait for custom color role overrides (foundational for #6)

## Why
PR #7 used hardcoded inline styles with `border-radius: 9999px` pills and hex colors — this didn't match Filament's actual design (which uses `rounded-md`, `ring-1 ring-inset`, OKLCH variables). The table headers also used uppercase styling that Filament doesn't use.

## Test plan
- [x] All 48 tests pass (12 table tests including OKLCH variable injection)
- [x] Pint clean
- [x] PHPStan clean
- [x] Integration tests produce valid PNG screenshots

Relates to #1, #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)