### PR TITLE
Fix array-based columns missing getColor callback

### DIFF
--- a/src/Renderers/TableRenderer.php
+++ b/src/Renderers/TableRenderer.php
@@ -66,6 +66,7 @@ class TableRenderer extends BaseRenderer
                 'label' => $column['label'] ?? str($column['name'] ?? '')->headline()->toString(),
                 'badge' => $column['badge'] ?? false,
                 'color' => $column['color'] ?? null,
+                'getColor' => $column['getColor'] ?? null,
             ];
         }
 

--- a/tests/Unit/TableRendererTest.php
+++ b/tests/Unit/TableRendererTest.php
@@ -150,6 +150,31 @@ it('renders badge with default primary color when no color specified', function 
         ->toContain('fi-color-primary');
 });
 
+it('renders array column with getColor callback for dynamic per-record badge colors', function () {
+    $html = FilamentShot::table()
+        ->columns([
+            [
+                'name' => 'status',
+                'badge' => true,
+                'getColor' => fn (string $state): string => match ($state) {
+                    'Blocked' => 'danger',
+                    'Active' => 'success',
+                    default => 'primary',
+                },
+            ],
+        ])
+        ->records([
+            ['status' => 'Blocked'],
+            ['status' => 'Active'],
+        ])
+        ->toHtml();
+
+    expect($html)
+        ->toContain('fi-badge')
+        ->toContain('fi-color-danger')
+        ->toContain('fi-color-success');
+});
+
 it('injects OKLCH color CSS variables', function () {
     $html = FilamentShot::table()
         ->columns([TextColumn::make('name')])


### PR DESCRIPTION
## Summary
- Fix `extractColumnData()` array branch missing `getColor` key, which silently stripped dynamic per-record badge color callbacks
- Add test covering array column with `getColor` callback returning different colors per record

Fixes #8

## Test plan
- [x] `vendor/bin/pest --no-coverage` — 49 tests pass
- [x] `vendor/bin/pint` — pass
- [x] `vendor/bin/phpstan analyse` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)