### PR TITLE
Fix extra CSS classes applied to wrong element in array renderCell

### DIFF
--- a/src/Support/ColumnAdapter.php
+++ b/src/Support/ColumnAdapter.php
@@ -88,15 +88,15 @@ class ColumnAdapter implements ArrayAccess
             $badgeClasses = self::resolveBadgeClasses($colorName);
             $escapedValue = e($value);
 
-            return '<div class="fi-ta-text fi-ta-text-has-badges fi-ta-text-item ' . $extraClasses . '">'
-                . '<span class="fi-badge fi-size-sm ' . $badgeClasses . '">' . $escapedValue . '</span>'
+            return '<div class="fi-ta-text fi-ta-text-has-badges">'
+                . '<span class="fi-badge fi-size-sm ' . $badgeClasses . ' ' . $extraClasses . '">' . $escapedValue . '</span>'
                 . '</div>';
         }
 
         $escapedValue = e($value);
 
-        return '<div class="fi-ta-text ' . $extraClasses . '">'
-            . '<span class="fi-ta-text-item fi-size-sm">' . $escapedValue . '</span>'
+        return '<div class="fi-ta-text">'
+            . '<span class="fi-ta-text-item fi-size-sm ' . $extraClasses . '">' . $escapedValue . '</span>'
             . '</div>';
     }
 


### PR DESCRIPTION
## Summary
- Move `fi-font-*`, `fi-size-*`, `fi-align-*` classes from the outer `<div>` to the inner `<span>` where Filament's CSS rules target them
- Applies to both badge and non-badge branches in the array-source path of `renderCell()`

Fixes #13

## Test plan
- [x] 79 tests pass (151 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)