### PR TITLE
Fix unlayered * selector overriding Filament @layer styles

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -12,18 +12,11 @@
             {!! $colorVariables !!}
         }
 
-        * {
-            font-family: '{{ $font }}', ui-sans-serif, system-ui, sans-serif;
-        }
-
         body {
             margin: 0;
             padding: 24px;
-            background-color: {{ $darkMode ? '#111827' : '#f9fafb' }};
-        }
-
-        .fi-body {
             font-family: '{{ $font }}', ui-sans-serif, system-ui, sans-serif;
+            background-color: {{ $darkMode ? '#111827' : '#f9fafb' }};
         }
     </style>
     @if($extraCss)


### PR DESCRIPTION
## Summary
- Move `font-family` from `*` to `body` so Filament's `@layer` CSS rules (`fi-font-mono`, `fi-font-bold`, badge colors, etc.) can take effect
- Remove redundant `.fi-body` font-family rule

Fixes #15

## Test plan
- [x] 79 tests pass (151 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)