### PR TITLE
Define font CSS custom properties required by Filament's theme

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -9,6 +9,9 @@
 
         :root {
             --primary-color: {{ $primaryColor }};
+            --font-family: '{{ $font }}';
+            --mono-font-family: ui-monospace;
+            --serif-font-family: ui-serif;
             {!! $colorVariables !!}
         }
 


### PR DESCRIPTION
## Summary
- Add `--font-family`, `--mono-font-family`, and `--serif-font-family` CSS variables to `:root`
- Without these, Filament's `@layer` rules like `.fi-font-mono { font-family: var(--mono-font-family), ... }` produce invalid declarations that get silently discarded

Fixes #18

## Test plan
- [x] 79 tests pass (151 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)