### PR TITLE
Auto-fit screenshot height to content

### DIFF
--- a/src/Concerns/HasOutput.php
+++ b/src/Concerns/HasOutput.php
@@ -46,6 +46,7 @@ trait HasOutput
             $this->getWidth(),
             $this->getHeight(),
             $this->getDeviceScale(),
+            fitContent: $this->viewportHeight === null,
         );
     }
 }

--- a/src/Support/BrowsershotFactory.php
+++ b/src/Support/BrowsershotFactory.php
@@ -6,13 +6,17 @@ use Spatie\Browsershot\Browsershot;
 
 class BrowsershotFactory
 {
-    public function create(string $html, int $width, int $height, int $deviceScale): Browsershot
+    public function create(string $html, int $width, int $height, int $deviceScale, bool $fitContent = false): Browsershot
     {
         $browsershot = Browsershot::html($html)
             ->windowSize($width, $height)
             ->deviceScaleFactor($deviceScale)
             ->timeout(config('filament-shot.browsershot.timeout', 60))
             ->waitUntilNetworkIdle();
+
+        if ($fitContent) {
+            $browsershot->select('body');
+        }
 
         if ($nodeBinary = config('filament-shot.browsershot.node_binary')) {
             $browsershot->setNodeBinary($nodeBinary);


### PR DESCRIPTION
## Summary
- Use `select('body')` by default so screenshots capture only the body element's bounding box (content + padding), eliminating whitespace
- Setting explicit `->height(768)` disables auto-fit and uses fixed viewport dimensions

## Test plan
- [x] 79 tests pass (151 assertions)
- [x] PHPStan — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)