### PR TITLE
Strip loading spinners from static screenshots

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -18,6 +18,9 @@
         /* Hide Alpine.js-dependent elements since JS doesn't run in screenshots */
         [x-cloak] { display: none !important; }
 
+        /* Hide Livewire loading indicators — spinners visible in static HTML */
+        .fi-loading-indicator { display: none !important; }
+
         body {
             margin: 0;
             padding: 24px;

--- a/src/Renderers/BaseRenderer.php
+++ b/src/Renderers/BaseRenderer.php
@@ -57,6 +57,18 @@ abstract class BaseRenderer
         // Remove x-load-src attributes (localhost URLs trigger Browsershot security)
         $html = preg_replace('/\s*x-load-src="[^"]*"/', '', $html);
 
+        // Remove Livewire loading indicator elements.
+        // Elements with wire:loading (without .remove) are spinners that only show
+        // during Livewire requests. In static HTML they're visible and cause unwanted
+        // loading icons. Elements with wire:loading.remove are the normal-state icons
+        // that should remain visible.
+        $html = preg_replace('/<svg\b[^>]*wire:loading\.delay[^>]*>.*?<\/svg>/s', '', $html);
+
+        // Also strip wire:loading.remove attributes from normal icons so they render
+        // without Livewire-specific attributes that serve no purpose in static HTML.
+        $html = preg_replace('/\s*wire:loading\.remove[^"]*="[^"]*"/', '', $html);
+        $html = preg_replace('/\s*wire:target="[^"]*"/', '', $html);
+
         return $html;
     }
 }


### PR DESCRIPTION
## Summary
- Strip `wire:loading.delay` SVG elements (loading spinners that show during Livewire requests)
- Strip `wire:loading.remove` and `wire:target` attributes from normal icons
- Add CSS fallback to hide `.fi-loading-indicator` class
- `wire:loading.attr="disabled"` on buttons is left intact (harmless, no visual effect)

Fixes the issue where repeater action buttons and "Add to..." buttons showed loading spinner icons in generated screenshots.

## Test plan
- [x] All 94 unit tests pass
- [x] PHPStan clean
- [x] Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)