### PR TITLE
Add modal wrapper support for form screenshots

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -1,0 +1,38 @@
+{{-- Static modal wrapper for screenshots. Uses relative positioning instead of
+     fixed so Browsershot can measure and capture the content properly. --}}
+<div class="fi-modal fi-modal-open fi-absolute-positioning-context" aria-modal="true" role="dialog" style="position: relative; display: flex; align-items: center; justify-content: center; padding: 2rem; border-radius: 0.75rem; background-color: rgba(0, 0, 0, 0.4);">
+    <div class="fi-modal-window-ctn" style="position: relative; width: 100%;">
+        <div class="fi-modal-window fi-modal-window-has-close-btn fi-modal-window-has-content fi-modal-window-has-footer fi-align-start fi-width-lg" style="position: relative;">
+            <div class="fi-modal-header">
+                <button type="button" class="fi-modal-close-btn fi-icon-btn fi-icon-btn-size-lg fi-color fi-color-gray">
+                    <svg class="fi-icon fi-icon-size-lg" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" style="width: 1.25rem; height: 1.25rem;">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+
+                <div>
+                    <h2 class="fi-modal-heading">{{ $heading }}</h2>
+
+                    @if($description)
+                        <p class="fi-modal-description">{{ $description }}</p>
+                    @endif
+                </div>
+            </div>
+
+            <div class="fi-modal-content">
+                {!! $content !!}
+            </div>
+
+            <div class="fi-modal-footer fi-align-start">
+                <div class="fi-modal-footer-actions">
+                    <button type="button" class="fi-btn fi-btn-size-md fi-color fi-color-gray">
+                        <span class="fi-btn-label">{{ $cancelLabel }}</span>
+                    </button>
+                    <button type="submit" class="fi-btn fi-btn-size-md fi-color fi-color-primary">
+                        <span class="fi-btn-label">{{ $submitLabel }}</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Renderers/FormRenderer.php
+++ b/src/Renderers/FormRenderer.php
@@ -10,6 +10,14 @@ class FormRenderer extends BaseRenderer
 {
     protected array $state = [];
 
+    protected ?string $modalHeading = null;
+
+    protected ?string $modalDescription = null;
+
+    protected string $modalSubmitLabel = 'Submit';
+
+    protected string $modalCancelLabel = 'Cancel';
+
     public function __construct(
         protected array $components = [],
     ) {}
@@ -17,6 +25,34 @@ class FormRenderer extends BaseRenderer
     public function state(array $state): static
     {
         $this->state = $state;
+
+        return $this;
+    }
+
+    public function modal(string $heading): static
+    {
+        $this->modalHeading = $heading;
+
+        return $this;
+    }
+
+    public function modalDescription(string $description): static
+    {
+        $this->modalDescription = $description;
+
+        return $this;
+    }
+
+    public function modalSubmitLabel(string $label): static
+    {
+        $this->modalSubmitLabel = $label;
+
+        return $this;
+    }
+
+    public function modalCancelLabel(string $label): static
+    {
+        $this->modalCancelLabel = $label;
 
         return $this;
     }
@@ -45,7 +81,20 @@ class FormRenderer extends BaseRenderer
             app('view')->share('__livewire', null);
         }
 
-        return $this->injectFormValues($html, $component->data);
+        $html = $this->injectFormValues($html, $component->data);
+
+        if ($this->modalHeading !== null) {
+            $html = view('filament-shot::components.modal', [
+                'heading' => $this->modalHeading,
+                'description' => $this->modalDescription,
+                'submitLabel' => $this->modalSubmitLabel,
+                'cancelLabel' => $this->modalCancelLabel,
+                'content' => $html,
+                'darkMode' => $this->isDarkMode(),
+            ])->render();
+        }
+
+        return $html;
     }
 
     /**

--- a/tests/Unit/FormRendererTest.php
+++ b/tests/Unit/FormRendererTest.php
@@ -287,3 +287,51 @@ it('renders a repeater field with items', function () {
         ->toContain('Items')
         ->toContain('fi-fo-repeater');
 });
+
+it('renders a form inside a modal wrapper', function () {
+    $html = FilamentShot::form([
+        TextInput::make('name')->label('Full Name'),
+        Select::make('role')->label('Role')->options(['admin' => 'Admin', 'editor' => 'Editor']),
+    ])
+        ->modal('Assign Role')
+        ->modalDescription('Choose a role for this user')
+        ->modalSubmitLabel('Assign')
+        ->modalCancelLabel('Dismiss')
+        ->toHtml();
+
+    expect($html)
+        ->toContain('fi-modal')
+        ->toContain('fi-modal-window')
+        ->toContain('fi-modal-header')
+        ->toContain('fi-modal-heading')
+        ->toContain('Assign Role')
+        ->toContain('Choose a role for this user')
+        ->toContain('fi-modal-content')
+        ->toContain('fi-modal-footer')
+        ->toContain('Assign')
+        ->toContain('Dismiss')
+        ->toContain('Full Name')
+        ->toContain('fi-fo-text-input');
+});
+
+it('renders a modal without description', function () {
+    $html = FilamentShot::form([
+        TextInput::make('name')->label('Name'),
+    ])
+        ->modal('Quick Edit')
+        ->toHtml();
+
+    expect($html)
+        ->toContain('fi-modal')
+        ->toContain('Quick Edit')
+        ->not->toContain('<p class="fi-modal-description">');
+});
+
+it('renders a form without modal by default', function () {
+    $html = FilamentShot::form([
+        TextInput::make('name')->label('Name'),
+    ])->toHtml();
+
+    expect($html)
+        ->not->toContain('<h2 class="fi-modal-heading">');
+});


### PR DESCRIPTION
## Summary
- New `->modal('Heading')` method on `FormRenderer` to wrap forms in a Filament modal card
- Optional `->modalDescription()`, `->modalSubmitLabel()`, `->modalCancelLabel()` for customization
- Renders with semi-transparent backdrop, close button, header, content area, and footer buttons
- Works in both light and dark mode
- Uses static positioning (not fixed) for proper Browsershot capture

Closes #47

## Test plan
- [x] All 119 tests pass (3 new modal tests)
- [x] Light mode modal screenshot verified
- [x] Dark mode modal screenshot verified
- [x] PHPStan clean
- [x] Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)