### PR TITLE
Reduce modal padding and use Filament Blade components

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -1,14 +1,18 @@
 {{-- Static modal wrapper for screenshots. Uses relative positioning instead of
-     fixed so Browsershot can measure and capture the content properly. --}}
-<div class="fi-modal fi-modal-open fi-absolute-positioning-context" aria-modal="true" role="dialog" style="position: relative; display: flex; align-items: center; justify-content: center; padding: 2rem; border-radius: 0.75rem; background-color: rgba(0, 0, 0, 0.4);">
+     fixed so Browsershot can measure and capture the content properly.
+     Renders actual Filament button components for correct color styling. --}}
+<div class="fi-modal fi-modal-open fi-absolute-positioning-context" aria-modal="true" role="dialog" style="position: relative; display: flex; align-items: center; justify-content: center; padding: 0.25rem; border-radius: 0.75rem; background-color: rgba(0, 0, 0, 0.4);">
     <div class="fi-modal-window-ctn" style="position: relative; width: 100%;">
         <div class="fi-modal-window fi-modal-window-has-close-btn fi-modal-window-has-content fi-modal-window-has-footer fi-align-start fi-width-lg" style="position: relative;">
             <div class="fi-modal-header">
-                <button type="button" class="fi-modal-close-btn fi-icon-btn fi-icon-btn-size-lg fi-color fi-color-gray">
-                    <svg class="fi-icon fi-icon-size-lg" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" style="width: 1.25rem; height: 1.25rem;">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
+                <x-filament::icon-button
+                    color="gray"
+                    :icon="\Filament\Support\Icons\Heroicon::OutlinedXMark"
+                    icon-size="lg"
+                    label="Close"
+                    tabindex="-1"
+                    class="fi-modal-close-btn"
+                />
 
                 <div>
                     <h2 class="fi-modal-heading">{{ $heading }}</h2>
@@ -25,12 +29,12 @@
 
             <div class="fi-modal-footer fi-align-start">
                 <div class="fi-modal-footer-actions">
-                    <button type="button" class="fi-btn fi-btn-size-md fi-color fi-color-gray">
-                        <span class="fi-btn-label">{{ $cancelLabel }}</span>
-                    </button>
-                    <button type="submit" class="fi-btn fi-btn-size-md fi-color fi-color-primary">
-                        <span class="fi-btn-label">{{ $submitLabel }}</span>
-                    </button>
+                    <x-filament::button color="gray">
+                        {{ $cancelLabel }}
+                    </x-filament::button>
+                    <x-filament::button color="primary">
+                        {{ $submitLabel }}
+                    </x-filament::button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Reduce backdrop padding from 2rem to 0.25rem
- Use actual `<x-filament::button>` and `<x-filament::icon-button>` for pixel-perfect button color styling instead of hardcoded CSS classes

## Test plan
- [x] All 119 tests pass
- [x] Light and dark mode verified visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)