### PR TITLE
Use Filament's actual modal component for rendering

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -1,42 +1,22 @@
-{{-- Static modal wrapper for screenshots. Uses relative positioning instead of
-     fixed so Browsershot can measure and capture the content properly.
-     Renders actual Filament button components for correct color styling. --}}
-<div class="fi-modal fi-modal-open fi-absolute-positioning-context" aria-modal="true" role="dialog" style="position: relative; display: flex; align-items: center; justify-content: center; padding: 0.25rem; border-radius: 0.75rem; background-color: rgba(0, 0, 0, 0.4);">
-    <div class="fi-modal-window-ctn" style="position: relative; width: 100%;">
-        <div class="fi-modal-window fi-modal-window-has-close-btn fi-modal-window-has-content fi-modal-window-has-footer fi-align-start fi-width-lg" style="position: relative;">
-            <div class="fi-modal-header">
-                <x-filament::icon-button
-                    color="gray"
-                    :icon="\Filament\Support\Icons\Heroicon::OutlinedXMark"
-                    icon-size="lg"
-                    label="Close"
-                    tabindex="-1"
-                    class="fi-modal-close-btn"
-                />
+{{-- Renders form content inside Filament's actual modal component.
+     CSS overrides in base.blade.php force visibility and static positioning
+     since Alpine.js doesn't run in screenshots. --}}
+<x-filament::modal
+    id="shot-modal"
+    :close-by-clicking-away="false"
+    :close-by-escaping="false"
+    width="lg"
+    :heading="$heading"
+    :description="$description"
+>
+    {!! $content !!}
 
-                <div>
-                    <h2 class="fi-modal-heading">{{ $heading }}</h2>
-
-                    @if($description)
-                        <p class="fi-modal-description">{{ $description }}</p>
-                    @endif
-                </div>
-            </div>
-
-            <div class="fi-modal-content">
-                {!! $content !!}
-            </div>
-
-            <div class="fi-modal-footer fi-align-start">
-                <div class="fi-modal-footer-actions">
-                    <x-filament::button color="gray">
-                        {{ $cancelLabel }}
-                    </x-filament::button>
-                    <x-filament::button color="primary">
-                        {{ $submitLabel }}
-                    </x-filament::button>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
+    <x-slot name="footer">
+        <x-filament::button color="gray">
+            {{ $cancelLabel }}
+        </x-filament::button>
+        <x-filament::button color="primary">
+            {{ $submitLabel }}
+        </x-filament::button>
+    </x-slot>
+</x-filament::modal>

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -21,6 +21,31 @@
         /* Hide Livewire loading indicators — spinners visible in static HTML */
         .fi-loading-indicator { display: none !important; }
 
+        /* Force Filament modal visible and static for screenshots.
+           The modal component uses Alpine.js (x-cloak, x-show) which hides
+           everything by default. Override to force visibility and use relative
+           positioning so Browsershot can measure content height. */
+        .fi-modal[x-cloak] {
+            display: flex !important;
+            position: relative !important;
+            padding: 0.25rem;
+            border-radius: 0.75rem;
+            background-color: rgba(0, 0, 0, 0.4);
+        }
+        .fi-modal .fi-modal-close-overlay {
+            display: block !important;
+            position: absolute !important;
+            inset: 0;
+            border-radius: 0.75rem;
+        }
+        .fi-modal .fi-modal-window-ctn {
+            position: relative !important;
+            width: 100%;
+        }
+        .fi-modal .fi-modal-window {
+            position: relative !important;
+        }
+
         /* FileUpload: style as FilePond dropzone since JS doesn't initialize */
         .fi-fo-file-upload {
             position: relative;


### PR DESCRIPTION
## Summary
- Replace hand-crafted modal HTML with `<x-filament::modal>` component
- Add CSS overrides in base layout to force visibility (`x-cloak`/`x-show` → visible) and static positioning (`fixed` → `relative`) for screenshot capture
- Future-proof: any Filament modal styling updates will automatically apply

## Test plan
- [x] All 119 tests pass
- [x] Light mode modal verified visually
- [x] Dark mode modal verified visually
- [x] Non-modal forms unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)