### PR TITLE
Remove dark backdrop from modal screenshots

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -28,15 +28,9 @@
         .fi-modal[x-cloak] {
             display: flex !important;
             position: relative !important;
-            padding: 0.25rem;
-            border-radius: 0.75rem;
-            background-color: rgba(0, 0, 0, 0.4);
         }
         .fi-modal .fi-modal-close-overlay {
-            display: block !important;
-            position: absolute !important;
-            inset: 0;
-            border-radius: 0.75rem;
+            display: none !important;
         }
         .fi-modal .fi-modal-window-ctn {
             position: relative !important;


### PR DESCRIPTION
## Summary
- Remove the semi-transparent dark overlay behind the modal card
- Modal now renders cleanly on the page background

## Test plan
- [x] All 119 tests pass
- [x] Light and dark mode verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)