### PR TITLE
Fix modal footer button order

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -12,11 +12,11 @@
     {!! $content !!}
 
     <x-slot name="footer">
-        <x-filament::button color="gray">
-            {{ $cancelLabel }}
-        </x-filament::button>
         <x-filament::button color="primary">
             {{ $submitLabel }}
+        </x-filament::button>
+        <x-filament::button color="gray">
+            {{ $cancelLabel }}
         </x-filament::button>
     </x-slot>
 </x-filament::modal>


### PR DESCRIPTION
## Summary
- Swap button order: primary action first, cancel second — matching Filament's actual modal layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)