### PR TITLE
Add field highlighting support via CSS injection

### DIFF
--- a/src/Concerns/HasHighlight.php
+++ b/src/Concerns/HasHighlight.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace CCK\FilamentShot\Concerns;
+
+trait HasHighlight
+{
+    /** @var array<int, array{key: string, color: string, style: string}> */
+    protected array $highlights = [];
+
+    public function highlight(string $fieldKey, string $color = '#ef4444', string $style = 'outline'): static
+    {
+        $this->highlights[] = ['key' => $fieldKey, 'color' => $color, 'style' => $style];
+
+        return $this;
+    }
+
+    public function getHighlightCss(): string
+    {
+        if (empty($this->highlights)) {
+            return '';
+        }
+
+        return implode("\n", array_map(function (array $h): string {
+            $cssId = '#' . str_replace('.', '\\.', 'form.' . $h['key']);
+            $wrapperSelector = "[data-field-wrapper]:has({$cssId})";
+            $color = $h['color'];
+
+            return match ($h['style']) {
+                'box' => "{$wrapperSelector} { outline: 3px solid {$color} !important; outline-offset: 4px; border-radius: 4px; background-color: {$color}22 !important; }",
+                'underline' => "{$cssId} { border-bottom: 3px solid {$color} !important; }",
+                default => "{$wrapperSelector} { outline: 3px solid {$color} !important; outline-offset: 4px; border-radius: 4px; }",
+            };
+        }, $this->highlights));
+    }
+}

--- a/src/Renderers/BaseRenderer.php
+++ b/src/Renderers/BaseRenderer.php
@@ -3,6 +3,7 @@
 namespace CCK\FilamentShot\Renderers;
 
 use CCK\FilamentShot\Concerns\HasFont;
+use CCK\FilamentShot\Concerns\HasHighlight;
 use CCK\FilamentShot\Concerns\HasOutput;
 use CCK\FilamentShot\Concerns\HasTheme;
 use CCK\FilamentShot\Concerns\HasViewport;
@@ -11,6 +12,7 @@ use CCK\FilamentShot\Support\AssetResolver;
 abstract class BaseRenderer
 {
     use HasFont;
+    use HasHighlight;
     use HasOutput;
     use HasTheme;
     use HasViewport;
@@ -35,7 +37,7 @@ abstract class BaseRenderer
             'primaryColor' => $this->getPrimaryColor(),
             'colorVariables' => $this->getColorCssVariables(),
             'themeCss' => $resolver->getThemeCssContent(),
-            'extraCss' => $resolver->getExtraCss(),
+            'extraCss' => $resolver->getExtraCss() . "\n" . $this->getHighlightCss(),
             'content' => $this->renderContent(),
             'contentWidth' => $this->getWidth() . 'px',
             'font' => $this->getFont(),

--- a/tests/Unit/HighlightTest.php
+++ b/tests/Unit/HighlightTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use CCK\FilamentShot\Renderers\FormRenderer;
+
+it('returns empty string when no highlights set', function () {
+    $renderer = new FormRenderer([]);
+    expect($renderer->getHighlightCss())->toBe('');
+});
+
+it('generates outline CSS for a simple field key', function () {
+    $renderer = new FormRenderer([]);
+    $renderer->highlight('minimum_amount');
+    $css = $renderer->getHighlightCss();
+    expect($css)->toContain('#form\\.minimum_amount');
+    expect($css)->toContain('#ef4444');
+    expect($css)->toContain('!important');
+    expect($css)->toContain('[data-field-wrapper]');
+});
+
+it('escapes dots in nested field keys', function () {
+    $renderer = new FormRenderer([]);
+    $renderer->highlight('distribution_configuration.amount');
+    $css = $renderer->getHighlightCss();
+    expect($css)->toContain('#form\\.distribution_configuration\\.amount');
+});
+
+it('supports custom color', function () {
+    $renderer = new FormRenderer([]);
+    $renderer->highlight('email', '#3b82f6');
+    expect($renderer->getHighlightCss())->toContain('#3b82f6');
+});
+
+it('supports multiple highlights', function () {
+    $renderer = new FormRenderer([]);
+    $renderer->highlight('name')->highlight('email', '#3b82f6');
+    $css = $renderer->getHighlightCss();
+    expect($css)->toContain('form\\.name');
+    expect($css)->toContain('form\\.email');
+});
+
+it('supports box style', function () {
+    $renderer = new FormRenderer([]);
+    $renderer->highlight('name', '#ef4444', 'box');
+    expect($renderer->getHighlightCss())->toContain('background-color');
+});
+
+it('supports underline style', function () {
+    $renderer = new FormRenderer([]);
+    $renderer->highlight('name', '#ef4444', 'underline');
+    expect($renderer->getHighlightCss())->toContain('border-bottom');
+});
+
+it('supports fluent chaining', function () {
+    $renderer = new FormRenderer([]);
+    $result = $renderer->highlight('name');
+    expect($result)->toBeInstanceOf(FormRenderer::class);
+});


### PR DESCRIPTION
## Summary

- Adds `HasHighlight` trait with a `->highlight(fieldKey, color, style)` method available on all renderers
- Generates CSS targeting `[data-field-wrapper]:has(#form\.{key})` — the correct Filament v4/v5 wrapper selector
- Supports 3 styles: `outline` (default), `box` (outline + tinted background), `underline`
- Multiple `->highlight()` calls accumulate; CSS is merged into `extraCss` at render time
- 8 unit tests covering all styles, nested key escaping, multiple highlights, and fluent chaining

## Usage

```php
FilamentShot::form([...])
    ->state([...])
    ->highlight('minimum_amount')               // red outline (default)
    ->highlight('email', '#3b82f6')             // blue outline
    ->highlight('nested.field', '#f59e0b', 'box')  // amber box
    ->save('annotated.png');
```

Closes #80

## Test plan

- [x] \`vendor/bin/pest tests/Unit/HighlightTest.php --no-coverage\` — 8 tests pass
- [x] \`vendor/bin/phpstan analyse\` — no errors
- [x] \`vendor/bin/pint\` — no violations
- [x] Manual screenshot verified highlight renders correctly on target field

🤖 Generated with [Claude Code](https://claude.com/claude-code)