### PR TITLE
Fix table row white background and page background color

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -80,12 +80,19 @@
             color: rgb(156 163 175);
         }
 
+        /* Table rows: ensure white background so they don't inherit gray from grid context */
+        @layer base {
+            .fi-ta-table > tbody > tr:not(.fi-striped) {
+                background-color: #ffffff;
+            }
+        }
+
         body {
             margin: 0;
             padding: 24px;
             min-height: auto !important;
             font-family: '{{ $font }}', ui-sans-serif, system-ui, sans-serif;
-            background-color: {{ $darkMode ? '#111827' : '#f9fafb' }};
+            background-color: {{ $darkMode ? '#111827' : '#ffffff' }};
         }
     </style>
     @if($extraCss)


### PR DESCRIPTION
## Summary

- Change body background from `#f9fafb` (gray-50) to `#ffffff` — component screenshots no longer have a gray page surround
- Add `@layer base` CSS rule to force table `tbody` rows to white background, fixing gray bleed-through caused by `fi-ta-content`'s `display:grid` layout context

## Root Cause

`fi-ta-content` has `display:grid` in Filament's compiled CSS. Table rows (`fi-ta-row`) have no explicit background, so they're transparent. The gray body background was bleeding through, making data rows appear gray even without `.fi-striped`.

## Test plan

- [ ] Run `vendor/bin/pest tests/Unit --no-coverage` — all unit tests pass
- [ ] Verify table screenshots render with white rows (not gray)
- [ ] Verify striped tables still show alternating gray rows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)