### PR TITLE
Add reorderable table drag handles and fix collapsed nav chevron

### DIFF
--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -12,7 +12,7 @@
     <nav class="fi-sidebar-nav">
         <ul class="fi-sidebar-nav-groups">
             @foreach($groups as $group)
-                <li class="fi-sidebar-group fi-collapsible {{ !empty($group['items']) && collect($group['items'])->contains('isActive', true) ? 'fi-active' : '' }}">
+                <li class="fi-sidebar-group fi-collapsible {{ !empty($group['items']) && collect($group['items'])->contains('isActive', true) ? 'fi-active' : '' }} {{ $group['isCollapsed'] ? 'fi-collapsed' : '' }}">
                     @if($group['label'])
                         <div class="fi-sidebar-group-btn">
                             @if($group['icon'])

--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -36,6 +36,9 @@
             <table class="fi-ta-table">
                 <thead>
                     <tr>
+                        @if($reorderable)
+                            <th class="fi-ta-header-cell"></th>
+                        @endif
                         @if(!empty($bulkActions))
                             <th class="fi-ta-cell fi-ta-selection-cell">
                                 <input type="checkbox" class="fi-ta-page-checkbox fi-checkbox-input" {{ count($selectedRows) === count($records) && count($records) > 0 ? 'checked' : '' }} />
@@ -54,6 +57,15 @@
                 <tbody>
                     @forelse($records as $index => $record)
                         <tr class="fi-ta-row {{ $striped && $index % 2 === 1 ? 'fi-striped' : '' }}">
+                            @if($reorderable)
+                                <td class="fi-ta-cell">
+                                    <button class="fi-ta-reorder-handle fi-icon-btn" type="button">
+                                        <svg class="fi-icon fi-size-md" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                            <path fill-rule="evenodd" d="M2 6.75A.75.75 0 0 1 2.75 6h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 6.75Zm0 6.5a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd"/>
+                                        </svg>
+                                    </button>
+                                </td>
+                            @endif
                             @if(!empty($bulkActions))
                                 <td class="fi-ta-cell fi-ta-selection-cell">
                                     <input type="checkbox" class="fi-ta-record-checkbox fi-checkbox-input" {{ in_array($index, $selectedRows) ? 'checked' : '' }} />
@@ -76,7 +88,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="{{ (!empty($bulkActions) ? 1 : 0) + count($columns) + (!empty($actions) ? 1 : 0) }}">
+                            <td colspan="{{ ($reorderable ? 1 : 0) + (!empty($bulkActions) ? 1 : 0) + count($columns) + (!empty($actions) ? 1 : 0) }}">
                                 <div class="fi-ta-empty-state">
                                     <div class="fi-ta-empty-state-content">
                                         <p class="fi-ta-empty-state-description">No records found.</p>

--- a/src/Renderers/TableRenderer.php
+++ b/src/Renderers/TableRenderer.php
@@ -25,6 +25,8 @@ class TableRenderer extends BaseRenderer
 
     protected array $selectedRows = [];
 
+    protected bool $reorderable = false;
+
     public function columns(array $columns): static
     {
         $this->columns = $columns;
@@ -81,6 +83,13 @@ class TableRenderer extends BaseRenderer
         return $this;
     }
 
+    public function reorderable(bool $reorderable = true): static
+    {
+        $this->reorderable = $reorderable;
+
+        return $this;
+    }
+
     protected function renderContent(): string
     {
         $columns = array_map(
@@ -109,6 +118,7 @@ class TableRenderer extends BaseRenderer
             'actions' => $actions,
             'bulkActions' => $bulkActions,
             'selectedRows' => $this->selectedRows,
+            'reorderable' => $this->reorderable,
             'linkPrimaryClasses' => $linkPrimaryClasses,
             'linkDangerClasses' => $linkDangerClasses,
         ])->render();

--- a/tests/Unit/CollapsedChevronTest.php
+++ b/tests/Unit/CollapsedChevronTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use CCK\FilamentShot\FilamentShot;
+use Filament\Navigation\NavigationGroup;
+use Filament\Navigation\NavigationItem;
+
+it('adds fi-collapsed class to collapsed navigation groups', function () {
+    $html = FilamentShot::navigation()
+        ->items([
+            NavigationGroup::make('Open Group')
+                ->items([
+                    NavigationItem::make('Item 1')->icon('heroicon-o-home'),
+                ]),
+            NavigationGroup::make('Closed Group')
+                ->collapsed()
+                ->items([
+                    NavigationItem::make('Item 2')->icon('heroicon-o-cog-6-tooth'),
+                ]),
+        ])
+        ->heading('Test')
+        ->renderHtml();
+
+    // The collapsed group's <li> should have fi-collapsed class
+    expect($html)->toMatch('/<li[^>]*fi-sidebar-group[^>]*fi-collapsed/');
+});
+
+it('does not add fi-collapsed class to expanded groups', function () {
+    $html = FilamentShot::navigation()
+        ->items([
+            NavigationGroup::make('Open Group')
+                ->items([
+                    NavigationItem::make('Item 1')->icon('heroicon-o-home'),
+                ]),
+        ])
+        ->heading('Test')
+        ->renderHtml();
+
+    // No group <li> should have fi-collapsed
+    expect($html)->not->toMatch('/<li[^>]*fi-sidebar-group[^>]*fi-collapsed/');
+});
+
+it('hides items of collapsed groups', function () {
+    $html = FilamentShot::navigation()
+        ->items([
+            NavigationGroup::make('Closed Group')
+                ->collapsed()
+                ->items([
+                    NavigationItem::make('Hidden Item')->icon('heroicon-o-home'),
+                ]),
+        ])
+        ->heading('Test')
+        ->renderHtml();
+
+    // The group label should be visible
+    expect($html)->toContain('Closed Group');
+
+    // The items should NOT be rendered (isCollapsed hides them)
+    expect($html)->not->toContain('Hidden Item');
+});
+
+it('shows only expanded group in mixed state', function () {
+    $html = FilamentShot::navigation()
+        ->items([
+            NavigationGroup::make('Expanded')
+                ->items([
+                    NavigationItem::make('Visible Item')->icon('heroicon-o-home'),
+                ]),
+            NavigationGroup::make('Collapsed')
+                ->collapsed()
+                ->items([
+                    NavigationItem::make('Hidden Item')->icon('heroicon-o-cog-6-tooth'),
+                ]),
+        ])
+        ->heading('Test')
+        ->renderHtml();
+
+    expect($html)
+        ->toContain('Visible Item')
+        ->not->toContain('Hidden Item')
+        ->toContain('Expanded')
+        ->toContain('Collapsed');
+
+    // Exactly one group <li> should have fi-collapsed
+    preg_match_all('/<li[^>]*fi-sidebar-group[^>]*fi-collapsed/', $html, $matches);
+    expect(count($matches[0]))->toBe(1);
+});

--- a/tests/Unit/ReorderableTableTest.php
+++ b/tests/Unit/ReorderableTableTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use CCK\FilamentShot\FilamentShot;
+use Filament\Tables\Columns\TextColumn;
+
+it('renders a reorderable table with drag handle cells', function () {
+    $html = FilamentShot::table()
+        ->columns([
+            TextColumn::make('name'),
+            TextColumn::make('email'),
+        ])
+        ->records([
+            ['name' => 'Alice', 'email' => 'alice@example.com'],
+            ['name' => 'Bob', 'email' => 'bob@example.com'],
+        ])
+        ->reorderable()
+        ->toHtml();
+
+    // Should contain the reorder handle button elements (one per row)
+    expect($html)->toMatch('/<button[^>]*fi-ta-reorder-handle/');
+
+    // Should have drag handle buttons in each row (2 records = 2 buttons)
+    preg_match_all('/<button[^>]*fi-ta-reorder-handle/', $html, $matches);
+    expect(count($matches[0]))->toBe(2);
+
+    // Should still render normal columns
+    expect($html)
+        ->toContain('Alice')
+        ->toContain('Bob')
+        ->toContain('alice@example.com');
+});
+
+it('does not render drag handles when reorderable is not set', function () {
+    $html = FilamentShot::table()
+        ->columns([TextColumn::make('name')])
+        ->records([['name' => 'Alice']])
+        ->toHtml();
+
+    expect($html)->not->toMatch('/<button[^>]*fi-ta-reorder-handle/');
+});
+
+it('renders drag handle as first cell in each row', function () {
+    $html = FilamentShot::table()
+        ->columns([TextColumn::make('name')])
+        ->records([['name' => 'Alice']])
+        ->reorderable()
+        ->toHtml();
+
+    // The reorder handle button should appear before the data cell content
+    preg_match('/<button[^>]*fi-ta-reorder-handle/', $html, $handleMatch, PREG_OFFSET_CAPTURE);
+    $handlePos = $handleMatch[0][1];
+    $namePos = strpos($html, 'Alice');
+
+    expect($handlePos)->toBeLessThan($namePos);
+});
+
+it('renders drag handle icon with bars SVG', function () {
+    $html = FilamentShot::table()
+        ->columns([TextColumn::make('name')])
+        ->records([['name' => 'Alice']])
+        ->reorderable()
+        ->toHtml();
+
+    // Should contain a button with both fi-ta-reorder-handle and fi-icon-btn
+    expect($html)->toMatch('/<button[^>]*fi-ta-reorder-handle fi-icon-btn/');
+
+    // Should contain an SVG inside the handle
+    expect($html)->toMatch('/<button[^>]*fi-ta-reorder-handle[^>]*>.*?<svg/s');
+});

--- a/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__table_striped__2.txt
+++ b/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__table_striped__2.txt
@@ -175,7 +175,7 @@
             <table class="fi-ta-table">
                 <thead>
                     <tr>
-                                                                            <th class="fi-ta-header-cell">
+                                                                                                    <th class="fi-ta-header-cell">
                                 Name
                             </th>
                                                     <th class="fi-ta-header-cell">
@@ -185,7 +185,7 @@
                 </thead>
                 <tbody>
                                             <tr class="fi-ta-row ">
-                                                                                        <td class="fi-ta-cell">
+                                                                                                                    <td class="fi-ta-cell">
                                     <div class="fi-ta-text"><span class="fi-ta-text-item fi-size-sm fi-size-sm">Alice</span></div>
                                 </td>
                                                             <td class="fi-ta-cell">
@@ -193,7 +193,7 @@
                                 </td>
                                                                                 </tr>
                                             <tr class="fi-ta-row fi-striped">
-                                                                                        <td class="fi-ta-cell">
+                                                                                                                    <td class="fi-ta-cell">
                                     <div class="fi-ta-text"><span class="fi-ta-text-item fi-size-sm fi-size-sm">Bob</span></div>
                                 </td>
                                                             <td class="fi-ta-cell">
@@ -201,7 +201,7 @@
                                 </td>
                                                                                 </tr>
                                             <tr class="fi-ta-row ">
-                                                                                        <td class="fi-ta-cell">
+                                                                                                                    <td class="fi-ta-cell">
                                     <div class="fi-ta-text"><span class="fi-ta-text-item fi-size-sm fi-size-sm">Charlie</span></div>
                                 </td>
                                                             <td class="fi-ta-cell">

--- a/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__table_with_badges__2.txt
+++ b/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__table_with_badges__2.txt
@@ -182,7 +182,7 @@
             <table class="fi-ta-table">
                 <thead>
                     <tr>
-                                                                            <th class="fi-ta-header-cell">
+                                                                                                    <th class="fi-ta-header-cell">
                                 Name
                             </th>
                                                     <th class="fi-ta-header-cell">
@@ -192,7 +192,7 @@
                 </thead>
                 <tbody>
                                             <tr class="fi-ta-row ">
-                                                                                        <td class="fi-ta-cell">
+                                                                                                                    <td class="fi-ta-cell">
                                     <div class="fi-ta-text"><span class="fi-ta-text-item fi-size-sm fi-size-sm">Alice</span></div>
                                 </td>
                                                             <td class="fi-ta-cell">
@@ -200,7 +200,7 @@
                                 </td>
                                                                                 </tr>
                                             <tr class="fi-ta-row ">
-                                                                                        <td class="fi-ta-cell">
+                                                                                                                    <td class="fi-ta-cell">
                                     <div class="fi-ta-text"><span class="fi-ta-text-item fi-size-sm fi-size-sm">Bob</span></div>
                                 </td>
                                                             <td class="fi-ta-cell">


### PR DESCRIPTION
## Summary
- **#87**: Add `->reorderable()` method to `TableRenderer` — renders a drag handle (bars icon) as the first cell in each table row
- **#88**: Add `fi-collapsed` CSS class to collapsed `NavigationGroup` elements so Filament's CSS rotates the chevron 180° automatically

Closes #87, closes #88

## Test plan
- [x] 4 unit tests for reorderable table (handle rendering, position, icon, absence when not set)
- [x] 4 unit tests for collapsed chevron (fi-collapsed class, expanded state, hidden items, mixed state)
- [x] Visual screenshot verification — drag handles render correctly, chevron rotates for collapsed groups
- [x] All 163 unit tests pass
- [x] PHPStan (level 4) passes
- [x] Pint code style passes
- [x] HTML snapshots updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)