### PR TITLE
Fix update-changelog workflow to use master branch

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: master
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@v1
@@ -26,6 +26,6 @@ jobs:
       - name: Commit updated CHANGELOG
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          branch: main
+          branch: master
           commit_message: Update CHANGELOG
           file_pattern: CHANGELOG.md


### PR DESCRIPTION
## Summary
- Changelog workflow was checking out `ref: main` and committing to `branch: main`
- Repo uses `master` — so the workflow failed on every release tag with a git fetch error
- Changes both `ref` and `branch` to `master`