### PR TITLE
Fix: declare blade-capture-directive as explicit dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "pestphp/pest-plugin-arch": "^3.0|^4.0",
         "pestphp/pest-plugin-laravel": "^3.0|^4.0",
         "pestphp/pest-plugin-livewire": "^3.0|^4.0",
+        "ryangjchandler/blade-capture-directive": "^1.0",
         "spatie/laravel-ray": "^1.26",
         "spatie/pest-plugin-snapshots": "^2.3",
         "ysfkaya/filament-phone-input": "^4.1"


### PR DESCRIPTION
## Summary
- `TestCase.php` explicitly registers `BladeCaptureDirectiveServiceProvider` but the package wasn't declared in `composer.json`
- CI doesn't use a lock file, so fresh composer resolution skipped this transitive dependency
- Adding it explicitly to `require-dev` ensures it's always installed

## Test plan
- [ ] Generate Examples CI should pass after this merge