### PR TITLE
Fix CI workflows: use composer update and correct master branch triggers

### DIFF
--- a/.github/workflows/generate-examples.yml
+++ b/.github/workflows/generate-examples.yml
@@ -26,7 +26,7 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-interaction
+        run: composer update --prefer-stable --prefer-dist --no-interaction
 
       - name: Install Puppeteer
         run: npm install puppeteer

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,9 @@ name: "Run Tests"
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- **generate-examples**: `composer install` was failing because there's no `composer.lock` checked in (it's gitignored). Switching to `composer update --prefer-stable` resolves all transitive deps correctly, including `ryangjchandler/blade-capture-directive` which `filament/support` requires
- **run-tests**: push/PR triggers were pointing at `main` instead of `master`, so the test suite never ran on pushes to master

## Test plan
- [ ] Generate Examples CI should pass (no more `BladeCaptureDirectiveServiceProvider` not found)
- [ ] Run Tests CI should now trigger on pushes to master