### PR TITLE
Fix run-tests: add --no-coverage flag for Pest v4 compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,4 +53,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest --ci --no-coverage


### PR DESCRIPTION
## Summary
Pest v4 with `--ci` exits code 1 when no coverage driver is available. Adding `--no-coverage` fixes this.