### PR TITLE
Fix run-tests: scope to Unit tests only (no Puppeteer needed)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,4 +53,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci --no-coverage
+        run: vendor/bin/pest tests/Unit --ci --no-coverage


### PR DESCRIPTION
## Summary
Feature tests (ImageSnapshot, etc.) require Puppeteer/Chrome which isn't installed in the matrix CI. Unit tests run fine without it. Screenshot/feature tests are covered by `generate-examples.yml` which already installs Puppeteer.