### PR TITLE
Fix run-tests: use --exclude-filter for HTML snapshot tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,4 +53,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest tests/Unit --ci --no-coverage --filter="not html snapshot"
+        run: vendor/bin/pest tests/Unit --ci --no-coverage --exclude-filter="html snapshot"


### PR DESCRIPTION
## Summary
Previous `--filter` with regex wasn't excluding correctly. Pest 4 has `--exclude-filter` which works properly. HTML snapshot tests compare exact Filament HTML which varies across tested package versions.