### PR TITLE
Fix: drop Filament v4 constraint so snapshot tests are version-stable

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,4 +53,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest tests/Unit --ci --no-coverage --exclude-filter="html snapshot"
+        run: vendor/bin/pest tests/Unit --ci --no-coverage

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^4.0|^5.0",
+        "filament/filament": "^5.0",
         "spatie/browsershot": "^5.2",
         "spatie/laravel-package-tools": "^1.15.0"
     },


### PR DESCRIPTION
## Root Cause
HTML snapshot tests were failing with `prefer-lowest` because `filament/filament: ^4.0|^5.0` allowed Composer to resolve Filament 4.x, which generates different HTML than our committed snapshots (which were created against v5).

## Fix
- `composer.json`: `^4.0|^5.0` → `^5.0`
  - Codebase already uses v5-only APIs (`SchemasServiceProvider`, `WidgetsServiceProvider`, etc.)
  - All snapshots, tests, and examples target v5
- `run-tests.yml`: remove `--exclude-filter="html snapshot"` workaround — snapshot tests can now run on all matrix combinations

## Test plan
- [ ] All matrix jobs pass including HTML snapshot tests