### PR TITLE
Fix: set minimum-stability to stable (Filament 5 is now stable)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,6 @@
             "phpstan/extension-installer": true
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
## Root Cause
`minimum-stability: dev` caused Composer to try early Filament 5 beta versions which have security advisories (PKSA-5bdf-2x61-v43c). This blocked dependency resolution in the `P8.2 - L11.* - prefer-stable` matrix job.

## Fix
Change `minimum-stability: dev` → `stable`. Filament 5 has been stable for a while — `dev` was set when it was still in beta.