### PR TITLE
Ignore Filament 5 security advisory (PKSA-5bdf-2x61-v43c) in composer audit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,11 @@
             "composer/package-versions-deprecated": true,
             "pestphp/pest-plugin": true,
             "phpstan/extension-installer": true
+        },
+        "audit": {
+            "ignore": {
+                "PKSA-5bdf-2x61-v43c": "filament/tables auth bypass does not affect filament-shot (screenshot renderer, no web authentication)"
+            }
         }
     },
     "minimum-stability": "stable",


### PR DESCRIPTION
## Root Cause
`prefer-lowest` CI jobs were blocked because many Filament 5 stable releases (v5.1.3, v5.2.x, etc.) have security advisory `PKSA-5bdf-2x61-v43c`. Composer refuses to install them during resolution.

## Why this is safe
This advisory is a **Filament web authentication bypass** — it only affects applications that use Filament as a web admin panel with real authentication. `filament-shot` is a screenshot renderer that generates PNG images from Filament components. There is no web server, no authentication layer, and no users — the advisory is entirely inapplicable.