### PR TITLE
Fix snapshot tests: normalize file:// paths to be machine-independent

### DIFF
--- a/tests/Unit/HtmlSnapshotTest.php
+++ b/tests/Unit/HtmlSnapshotTest.php
@@ -15,11 +15,13 @@ use function Spatie\Snapshots\assertMatchesSnapshot;
  * - replaces random Livewire component IDs with a fixed placeholder
  * - strips embedded <style> tag contents (Filament's compiled CSS changes
  *   between minor releases and is not part of our rendering logic)
+ * - normalizes absolute file:// paths to be machine-independent
  */
 function normalizeHtml(string $html): string
 {
     $html = preg_replace('/shot-(form|infolist|stats|table)-[A-Za-z0-9]{8}/', 'shot-$1-SNAPSHOT_ID', $html);
     $html = preg_replace('/<style[^>]*>.*?<\/style>/s', '<style>/* CSS stripped */</style>', $html);
+    $html = preg_replace('#file:///[^"]*vendor/#', 'file:///[path]/vendor/', $html);
 
     return $html;
 }

--- a/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__form_with_inputs__2.txt
+++ b/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__form_with_inputs__2.txt
@@ -262,11 +262,11 @@
     
     
     
-        <script src="file:///home/cck/filament-shot/vendor/livewire/livewire/dist/livewire.min.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/support/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/tables/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/notifications/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/schemas/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/actions/dist/index.js"></script>
+        <script src="file:///[path]/vendor/livewire/livewire/dist/livewire.min.js"></script>
+        <script src="file:///[path]/vendor/filament/support/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/tables/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/notifications/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/schemas/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/actions/dist/index.js"></script>
     </body>
 </html>

--- a/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__infolist__2.txt
+++ b/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__infolist__2.txt
@@ -227,11 +227,11 @@
     
     
     
-        <script src="file:///home/cck/filament-shot/vendor/livewire/livewire/dist/livewire.min.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/support/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/tables/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/notifications/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/schemas/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/actions/dist/index.js"></script>
+        <script src="file:///[path]/vendor/livewire/livewire/dist/livewire.min.js"></script>
+        <script src="file:///[path]/vendor/filament/support/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/tables/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/notifications/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/schemas/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/actions/dist/index.js"></script>
     </body>
 </html>

--- a/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__stats__2.txt
+++ b/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__stats__2.txt
@@ -197,11 +197,11 @@
     
     
     
-        <script src="file:///home/cck/filament-shot/vendor/livewire/livewire/dist/livewire.min.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/support/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/tables/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/notifications/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/schemas/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/actions/dist/index.js"></script>
+        <script src="file:///[path]/vendor/livewire/livewire/dist/livewire.min.js"></script>
+        <script src="file:///[path]/vendor/filament/support/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/tables/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/notifications/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/schemas/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/actions/dist/index.js"></script>
     </body>
 </html>

--- a/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__table_striped__2.txt
+++ b/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__table_striped__2.txt
@@ -76,11 +76,11 @@
     
     
     
-        <script src="file:///home/cck/filament-shot/vendor/livewire/livewire/dist/livewire.min.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/support/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/tables/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/notifications/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/schemas/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/actions/dist/index.js"></script>
+        <script src="file:///[path]/vendor/livewire/livewire/dist/livewire.min.js"></script>
+        <script src="file:///[path]/vendor/filament/support/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/tables/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/notifications/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/schemas/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/actions/dist/index.js"></script>
     </body>
 </html>

--- a/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__table_with_badges__2.txt
+++ b/tests/__snapshots__/HtmlSnapshotTest__it_html_snapshot__table_with_badges__2.txt
@@ -75,11 +75,11 @@
     
     
     
-        <script src="file:///home/cck/filament-shot/vendor/livewire/livewire/dist/livewire.min.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/support/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/tables/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/notifications/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/schemas/dist/index.js"></script>
-        <script src="file:///home/cck/filament-shot/vendor/filament/actions/dist/index.js"></script>
+        <script src="file:///[path]/vendor/livewire/livewire/dist/livewire.min.js"></script>
+        <script src="file:///[path]/vendor/filament/support/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/tables/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/notifications/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/schemas/dist/index.js"></script>
+        <script src="file:///[path]/vendor/filament/actions/dist/index.js"></script>
     </body>
 </html>


### PR DESCRIPTION
## Root Cause
Snapshots contained absolute `file:///home/cck/...` paths from local development. In CI these are `file:///home/runner/work/...`, causing mismatches.

## Fix
`normalizeHtml()` now also replaces `file:///[any path]/vendor/` with `file:///[path]/vendor/` so snapshots are portable between machines.

Regenerated all 5 snapshots with the normalized paths.