### PR TITLE
Fix snapshot tests: normalize CRLF for Windows CI

### DIFF
--- a/tests/Unit/HtmlSnapshotTest.php
+++ b/tests/Unit/HtmlSnapshotTest.php
@@ -12,6 +12,7 @@ use function Spatie\Snapshots\assertMatchesSnapshot;
 
 /**
  * Normalize volatile parts of Filament HTML before snapshotting:
+ * - normalizes line endings (Windows CRLF → LF)
  * - replaces random Livewire component IDs with a fixed placeholder
  * - strips embedded <style> tag contents (Filament's compiled CSS changes
  *   between minor releases and is not part of our rendering logic)
@@ -19,6 +20,7 @@ use function Spatie\Snapshots\assertMatchesSnapshot;
  */
 function normalizeHtml(string $html): string
 {
+    $html = str_replace("\r\n", "\n", $html);
     $html = preg_replace('/shot-(form|infolist|stats|table)-[A-Za-z0-9]{8}/', 'shot-$1-SNAPSHOT_ID', $html);
     $html = preg_replace('/<style[^>]*>.*?<\/style>/s', '<style>/* CSS stripped */</style>', $html);
     $html = preg_replace('#file:///[^"]*vendor/#', 'file:///[path]/vendor/', $html);


### PR DESCRIPTION
Windows uses \r\n line endings; stored snapshots use \n. Normalizing before comparison makes snapshots cross-platform.