### PR TITLE
Fix snapshot tests: enforce LF via .gitattributes on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # Path-based git attributes
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
+# Enforce LF line endings for snapshot files so tests pass on Windows
+tests/__snapshots__/**  eol=lf
+
 # Ignore all test and documentation with "export-ignore".
 /.github                export-ignore
 /.gitattributes         export-ignore


### PR DESCRIPTION
On Windows, git converts snapshot files to CRLF on checkout. Adding `eol=lf` for `tests/__snapshots__/` ensures LF on all platforms, matching the normalized HTML.