### PR TITLE
Fix snapshot path regex for Windows (file://D:\ format)

### DIFF
--- a/tests/Unit/HtmlSnapshotTest.php
+++ b/tests/Unit/HtmlSnapshotTest.php
@@ -23,7 +23,7 @@ function normalizeHtml(string $html): string
     $html = str_replace("\r\n", "\n", $html);
     $html = preg_replace('/shot-(form|infolist|stats|table)-[A-Za-z0-9]{8}/', 'shot-$1-SNAPSHOT_ID', $html);
     $html = preg_replace('/<style[^>]*>.*?<\/style>/s', '<style>/* CSS stripped */</style>', $html);
-    $html = preg_replace('#file:///[^"]*vendor/#', 'file:///[path]/vendor/', $html);
+    $html = preg_replace('#file://[^"]*[/\\\\]vendor[/\\\\]#', 'file:///[path]/vendor/', $html);
 
     return $html;
 }


### PR DESCRIPTION
Windows generates `file://D:\a\...\vendor\` paths with drive letter and backslashes. Previous regex only matched Unix `file:///`. Updated to handle both.