### PR TITLE
Fix snapshot path normalization for Windows backslashes within vendor paths

### DIFF
--- a/tests/Unit/HtmlSnapshotTest.php
+++ b/tests/Unit/HtmlSnapshotTest.php
@@ -23,7 +23,9 @@ function normalizeHtml(string $html): string
     $html = str_replace("\r\n", "\n", $html);
     $html = preg_replace('/shot-(form|infolist|stats|table)-[A-Za-z0-9]{8}/', 'shot-$1-SNAPSHOT_ID', $html);
     $html = preg_replace('/<style[^>]*>.*?<\/style>/s', '<style>/* CSS stripped */</style>', $html);
-    $html = preg_replace('#file://[^"]*[/\\\\]vendor[/\\\\]#', 'file:///[path]/vendor/', $html);
+    // Normalize backslashes in file:// URLs (Windows uses \ as path separator)
+    $html = preg_replace_callback('#file://[^"]+#', fn ($m) => str_replace('\\', '/', $m[0]), $html);
+    $html = preg_replace('#file:///[^"]*/vendor/#', 'file:///[path]/vendor/', $html);
 
     return $html;
 }


### PR DESCRIPTION
## Summary

- The previous `file://` path normalization regex replaced everything up to `vendor\` but left backslashes in the package path segment (e.g. `livewire\livewire/` remained unnormalized)
- Windows CI was producing `file:///[path]/vendor/livewire\livewire/dist/...` while snapshots expected `file:///[path]/vendor/livewire/livewire/dist/...`
- Fix: use `preg_replace_callback` to convert **all** backslashes in `file://` URLs to forward slashes first, then strip the machine-specific path prefix

## Test plan

- [ ] Linux CI jobs pass (snapshot normalization is unchanged for forward-slash paths)
- [ ] Windows CI jobs pass (backslashes within vendor paths are now also normalized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)