### PR TITLE
Fix snapshot path regex: match Windows file://D:/ format

### DIFF
--- a/tests/Unit/HtmlSnapshotTest.php
+++ b/tests/Unit/HtmlSnapshotTest.php
@@ -25,7 +25,7 @@ function normalizeHtml(string $html): string
     $html = preg_replace('/<style[^>]*>.*?<\/style>/s', '<style>/* CSS stripped */</style>', $html);
     // Normalize backslashes in file:// URLs (Windows uses \ as path separator)
     $html = preg_replace_callback('#file://[^"]+#', fn ($m) => str_replace('\\', '/', $m[0]), $html);
-    $html = preg_replace('#file:///[^"]*/vendor/#', 'file:///[path]/vendor/', $html);
+    $html = preg_replace('#file://[^"]*/vendor/#', 'file:///[path]/vendor/', $html);
 
     return $html;
 }


### PR DESCRIPTION
## Summary

- After normalizing backslashes in `file://` URLs, the path `file://D:/a/.../vendor/` still wasn't matched because the regex used `file:///` (3 slashes, Unix-style)
- Windows file URLs use `file://D:/` format (2 slashes + drive letter), not `file:///path` (3 slashes + absolute path)
- Fix: use `file://` in the regex to match both Unix (`file:///home/...`) and Windows (`file://D:/...`) formats

## Test plan

- [ ] Linux CI: `file:///home/.../vendor/` → `file:///[path]/vendor/` ✓
- [ ] Windows CI: `file://D:/a/.../vendor/` → `file:///[path]/vendor/` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)