### PR TITLE
Fix blank modal screenshots; accept body components in modal() (#150)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,12 @@
 # Path-based git attributes
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
-# Enforce LF line endings for snapshot files so tests pass on Windows
+# Enforce LF line endings for text snapshot files so tests pass on Windows
 tests/__snapshots__/**  eol=lf
+
+# Binary image snapshots must NOT undergo eol conversion — stripping CRLF from
+# PNG bytes corrupts the file signature and breaks image comparison.
+tests/__snapshots__/**/*.png  binary
 
 # Ignore all test and documentation with "export-ignore".
 /.github                export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `filament-shot` will be documented in this file.
 
+## Unreleased
+
+### Bug Fixes
+
+- **Fixed blank modal screenshots** (#150): `FilamentShot::modal()` and `FilamentShot::form()->modal()` produced empty PNGs because Filament's modal markup hides the inner `.fi-modal-window` via Alpine's `x-show="isWindowVisible"`, and the window container's viewport-tied grid layout (`min-height: 100%`, `max-height: calc(100dvh - 2rem)`) collapsed under the fitContent 1px viewport. The screenshot CSS now forces the window visible at its natural height.
+
+### New Features
+
+- **`FilamentShot::modal(array $components = [])`** (#150): the standalone modal renderer now accepts an optional components array, rendered inside the modal body via the form-rendering pipeline. Supports `->state()` and `->openFields()`. Matches the documented signature.
+
 ## v0.9.2 - 2026-03-26
 
 ### What's Changed

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -27,18 +27,34 @@
            set by x-show, keeping the modal visible in screenshots regardless of
            Alpine's state. */
         .fi-modal {
-            display: flex !important;
+            display: block !important;
             position: relative !important;
         }
         .fi-modal .fi-modal-close-overlay {
             display: none !important;
         }
+        /* Container is normally `display: grid` with `grid-template-rows: 1fr auto 1fr`
+           and `min-height: 100%` + `position: fixed`, which fills the viewport and pads
+           the window with empty filler rows. Flatten it to a static block so the window
+           sits at its natural height in document flow. */
         .fi-modal .fi-modal-window-ctn {
+            display: block !important;
             position: relative !important;
+            inset: auto !important;
+            min-height: 0 !important;
+            padding: 0 !important;
             width: 100%;
         }
+        /* The window carries `x-show="isWindowVisible"` (Alpine sets inline display:none)
+           plus `max-height: calc(100dvh - 2rem)` which collapses at small viewports.
+           Force it visible at natural height; !important beats Alpine's inline style. */
         .fi-modal .fi-modal-window {
+            display: flex !important;
             position: relative !important;
+            grid-row-start: auto !important;
+            height: auto !important;
+            max-height: none !important;
+            margin-inline: auto;
         }
 
         /* Force Filament notification visible for screenshots.

--- a/skills/filament-shot/SKILL.md
+++ b/skills/filament-shot/SKILL.md
@@ -144,12 +144,25 @@ FilamentShot::form([TextInput::make('name')])
     ->save('modal-form.png');
 ```
 
-Or a standalone modal without form fields:
+Or a standalone modal. Pass no arguments for a pure confirmation dialog:
 
 ```php
-FilamentShot::modal([TextInput::make('reason')])
+FilamentShot::modal()
+    ->heading('Confirm Deletion')
+    ->description('This action cannot be undone.')
+    ->color('danger')
+    ->icon('heroicon-o-trash')
+    ->iconColor('danger')
+    ->save('modal.png');
+```
+
+Or pass a components array to render fields inside the modal body (use `->state()` to fill them):
+
+```php
+FilamentShot::modal([TextInput::make('reason')->label('Reason for deletion')])
     ->heading('Confirm Deletion')
     ->color('danger')
+    ->state(['reason' => 'Duplicate account'])
     ->save('modal.png');
 ```
 

--- a/src/FilamentShot.php
+++ b/src/FilamentShot.php
@@ -13,6 +13,7 @@ use CCK\FilamentShot\Renderers\TableRenderer;
 use CCK\FilamentShot\Renderers\ViewRenderer;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
+use Filament\Schemas\Components\Component;
 
 class FilamentShot
 {
@@ -36,9 +37,12 @@ class FilamentShot
         return new StatsRenderer($stats);
     }
 
-    public static function modal(): ModalRenderer
+    /**
+     * @param  array<Component>  $components  Optional body components rendered inside the modal
+     */
+    public static function modal(array $components = []): ModalRenderer
     {
-        return new ModalRenderer;
+        return new ModalRenderer($components);
     }
 
     public static function notification(): NotificationRenderer

--- a/src/Renderers/FormRenderer.php
+++ b/src/Renderers/FormRenderer.php
@@ -102,6 +102,34 @@ class FormRenderer extends BaseRenderer
 
     protected function renderContent(): string
     {
+        $html = $this->renderSchemaHtml();
+
+        if ($this->modalHeading !== null) {
+            $html = view('filament-shot::components.modal', [
+                'heading' => $this->modalHeading,
+                'description' => $this->modalDescription,
+                'icon' => $this->modalIcon,
+                'iconColor' => $this->modalIconColor,
+                'color' => $this->modalColor,
+                'submitLabel' => $this->modalSubmitLabel,
+                'cancelLabel' => $this->modalCancelLabel,
+                'content' => $html,
+                'darkMode' => $this->isDarkMode(),
+            ])->render();
+        }
+
+        return $html;
+    }
+
+    /**
+     * Render the form schema to static HTML, applying all the state-injection
+     * and Alpine-resolution post-processors.
+     *
+     * Exposed publicly so other renderers (e.g. ModalRenderer) can embed a rendered
+     * schema inside their own layout without re-implementing the pipeline.
+     */
+    public function renderSchemaHtml(): string
+    {
         $this->ensureViewErrorBag();
 
         ShotFormComponent::prepareFor($this->components, $this->state);
@@ -131,23 +159,8 @@ class FormRenderer extends BaseRenderer
         $html = $this->fixBuilder($html);
         $html = $this->fixRichEditor($html);
         $html = $this->fixMarkdownEditor($html);
-        $html = $this->fixCodeEditor($html, $component->data);
 
-        if ($this->modalHeading !== null) {
-            $html = view('filament-shot::components.modal', [
-                'heading' => $this->modalHeading,
-                'description' => $this->modalDescription,
-                'icon' => $this->modalIcon,
-                'iconColor' => $this->modalIconColor,
-                'color' => $this->modalColor,
-                'submitLabel' => $this->modalSubmitLabel,
-                'cancelLabel' => $this->modalCancelLabel,
-                'content' => $html,
-                'darkMode' => $this->isDarkMode(),
-            ])->render();
-        }
-
-        return $html;
+        return $this->fixCodeEditor($html, $component->data);
     }
 
     /**

--- a/src/Renderers/ModalRenderer.php
+++ b/src/Renderers/ModalRenderer.php
@@ -2,10 +2,16 @@
 
 namespace CCK\FilamentShot\Renderers;
 
+use Filament\Schemas\Components\Component;
 use Illuminate\Support\ViewErrorBag;
 
 class ModalRenderer extends BaseRenderer
 {
+    /** @var array<string> Field names whose select dropdowns should render open */
+    protected array $openFields = [];
+
+    protected array $state = [];
+
     protected ?string $heading = null;
 
     protected ?string $description = null;
@@ -19,6 +25,32 @@ class ModalRenderer extends BaseRenderer
     protected string $submitLabel = 'Confirm';
 
     protected string $cancelLabel = 'Cancel';
+
+    /**
+     * @param  array<Component>  $components  Body components rendered inside the modal
+     */
+    public function __construct(
+        protected array $components = [],
+    ) {}
+
+    public function state(array $state): static
+    {
+        $this->state = $state;
+
+        return $this;
+    }
+
+    /**
+     * Specify which select fields should render with their dropdown open.
+     *
+     * @param  array<string>  $fields  Field names to render open
+     */
+    public function openFields(array $fields): static
+    {
+        $this->openFields = $fields;
+
+        return $this;
+    }
 
     public function heading(string $heading): static
     {
@@ -83,8 +115,32 @@ class ModalRenderer extends BaseRenderer
             'color' => $this->color,
             'submitLabel' => $this->submitLabel,
             'cancelLabel' => $this->cancelLabel,
-            'content' => '',
+            'content' => $this->renderBodyComponents(),
             'darkMode' => $this->isDarkMode(),
         ])->render();
+    }
+
+    /**
+     * Render the optional body components by reusing FormRenderer's schema pipeline.
+     *
+     * The font, width, and colour theme are applied by this renderer's base layout,
+     * so only the schema-affecting settings (state, open fields, dark mode) need to
+     * be forwarded to the inner renderer.
+     */
+    protected function renderBodyComponents(): string
+    {
+        if ($this->components === []) {
+            return '';
+        }
+
+        $form = (new FormRenderer($this->components))
+            ->state($this->state)
+            ->openFields($this->openFields);
+
+        if ($this->darkMode !== null) {
+            $this->darkMode ? $form->darkMode() : $form->lightMode();
+        }
+
+        return $form->renderSchemaHtml();
     }
 }

--- a/tests/Feature/ImageSnapshotTest.php
+++ b/tests/Feature/ImageSnapshotTest.php
@@ -119,6 +119,44 @@ it('image snapshot: stats', function () {
     @unlink($path);
 })->group('snapshot', 'integration');
 
+it('renders a standalone confirmation modal as a non-blank PNG', function () {
+    $path = tempnam(sys_get_temp_dir(), 'fs_') . '.png';
+
+    FilamentShot::modal()
+        ->heading('Confirm Deletion')
+        ->description('This action cannot be undone.')
+        ->submitLabel('Delete')
+        ->cancelLabel('Cancel')
+        ->icon('heroicon-o-trash')
+        ->iconColor('danger')
+        ->color('danger')
+        ->width(800)
+        ->save($path);
+
+    // Regression guard for #150: the modal must produce visible content,
+    // not an all-white image.
+    assertPngIsNotBlank($path);
+
+    @unlink($path);
+})->group('snapshot', 'integration');
+
+it('renders a modal with body components as a non-blank PNG', function () {
+    $path = tempnam(sys_get_temp_dir(), 'fs_') . '.png';
+
+    FilamentShot::modal([
+        TextInput::make('reason')->label('Reason for deletion'),
+    ])
+        ->heading('Confirm Deletion')
+        ->color('danger')
+        ->state(['reason' => 'Duplicate account'])
+        ->width(800)
+        ->save($path);
+
+    assertPngIsNotBlank($path);
+
+    @unlink($path);
+})->group('snapshot', 'integration');
+
 it('image snapshot: dark mode table', function () {
     $path = tempnam(sys_get_temp_dir(), 'fs_') . '.png';
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -70,3 +70,47 @@ function assertImageMatchesSnapshot(string $snapshotName, string $actualPngPath,
         . 'Run with UPDATE_SNAPSHOTS=true to regenerate.'
     );
 }
+
+/**
+ * Assert that a PNG contains meaningful non-white content (i.e. it is not blank).
+ *
+ * Guards against renderers that silently produce an all-white image — the failure
+ * mode behind issue #150, where modals captured nothing visible.
+ *
+ * @param  float  $minNonWhite  Minimum fraction of non-white pixels required (default 0.5%)
+ */
+function assertPngIsNotBlank(string $path, float $minNonWhite = 0.005): void
+{
+    expect(file_exists($path))->toBeTrue("PNG was not created: {$path}");
+
+    $img = imagecreatefromstring(file_get_contents($path));
+    expect($img)->not->toBeFalse("Could not load PNG: {$path}");
+
+    $w = imagesx($img);
+    $h = imagesy($img);
+    $nonWhite = 0;
+
+    for ($x = 0; $x < $w; $x += 2) {
+        for ($y = 0; $y < $h; $y += 2) {
+            $rgb = imagecolorat($img, $x, $y);
+            $r = ($rgb >> 16) & 0xFF;
+            $g = ($rgb >> 8) & 0xFF;
+            $b = $rgb & 0xFF;
+
+            if ($r < 248 || $g < 248 || $b < 248) {
+                $nonWhite++;
+            }
+        }
+    }
+
+    imagedestroy($img);
+
+    $sampled = (int) (ceil($w / 2) * ceil($h / 2));
+    $fraction = $sampled > 0 ? $nonWhite / $sampled : 0;
+
+    expect($fraction)->toBeGreaterThan(
+        $minNonWhite,
+        "PNG appears blank: only {$nonWhite} non-white pixels sampled ("
+        . round($fraction * 100, 3) . '%). Expected at least ' . round($minNonWhite * 100, 3) . '%.'
+    );
+}

--- a/tests/Unit/ModalRendererTest.php
+++ b/tests/Unit/ModalRendererTest.php
@@ -1,6 +1,44 @@
 <?php
 
 use CCK\FilamentShot\FilamentShot;
+use Filament\Forms\Components\TextInput;
+
+it('renders body components inside the modal', function () {
+    $html = FilamentShot::modal([
+        TextInput::make('reason')->label('Reason for deletion'),
+    ])
+        ->heading('Confirm Deletion')
+        ->color('danger')
+        ->toHtml();
+
+    expect($html)
+        ->toContain('fi-modal')
+        ->toContain('class="fi-modal-content"')
+        ->toContain('Reason for deletion')
+        ->toContain('wire:model')
+        ->toContain('Confirm Deletion');
+});
+
+it('injects state into modal body components', function () {
+    $html = FilamentShot::modal([
+        TextInput::make('reason'),
+    ])
+        ->heading('Confirm')
+        ->state(['reason' => 'Duplicate account'])
+        ->toHtml();
+
+    expect($html)->toContain('value="Duplicate account"');
+});
+
+it('renders an empty body when no components are given', function () {
+    $html = FilamentShot::modal()
+        ->heading('Confirm Action')
+        ->toHtml();
+
+    expect($html)
+        ->toContain('fi-modal')
+        ->not->toContain('class="fi-modal-content"');
+});
 
 it('renders a standalone confirmation modal', function () {
     $html = FilamentShot::modal()


### PR DESCRIPTION
Closes #150.

## Problem

Both `FilamentShot::modal()` and `FilamentShot::form()->modal()` produced ~1 KB blank white PNGs — even with an explicit `->height()`. Documented `FilamentShot::modal([...components])` also didn't match the source signature (`modal(): ModalRenderer`).

## Root cause (regression)

Modal examples rendered fine when the feature shipped; later changes broke them. Two compounding issues in how Filament's modal markup meets the screenshot CSS:

1. **Inner window hidden.** `.fi-modal-window` carries `x-show="isWindowVisible"`. Alpine (which now runs in screenshots) sets inline `display:none` on it. The CSS forced only `.fi-modal` visible — never the inner window holding the heading/body/footer. → blank regardless of viewport.
2. **Viewport-tied sizing collapsed.** The window container is `display:grid; grid-template-rows:1fr auto 1fr; min-height:100%` and the window has `max-height:calc(100dvh - 2rem)`. Under the fitContent 1px viewport these collapse to ~0.

## Fix

- **`base.blade.php`**: flatten the window container to a static block and force `.fi-modal-window` visible at natural height (`!important` beats Alpine's inline style).
- **`FilamentShot::modal(array $components = [])`**: now accepts an optional components array, rendered in the modal body by reusing FormRenderer's schema pipeline via the new public `FormRenderer::renderSchemaHtml()` — no duplication. Adds `->state()` and `->openFields()` to `ModalRenderer`. Matches the documented signature.
- **`.gitattributes`**: `eol=lf` was being applied to binary PNG snapshot references, stripping CRLF from their bytes and corrupting the file signature — which is *why no test caught the regression*. Scoped `*.png binary`.
- **Docs**: corrected the SKILL.md example (it claimed "without form fields" but passed a field).

## Tests

- Unit (runs in CI): 3 new `ModalRendererTest` cases — body components, state injection, empty body.
- Feature: 2 modal PNG **non-blank** regression guards + a reusable `assertPngIsNotBlank()` helper. Chose not-blank over pixel-snapshot — robust across environments, and a pixel snapshot just stores a blank on first run.

## Verification

Modal feature tests pass · `tests/Unit` 292 passed · Pint clean · PHPStan clean.

## Rendered output

Standalone confirmation and form-in-modal both render correctly (icon, heading, description, filled fields, action buttons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)